### PR TITLE
Add check for lines on solaris

### DIFF
--- a/lib/facter/util/pkgupdates.rb
+++ b/lib/facter/util/pkgupdates.rb
@@ -30,12 +30,15 @@ module Facter::Util::Pkgupdates
       end
     when 'Solaris'
       command = 'pkg list -u -H'
-      lines = Facter::Util::Resolution.exec(command).split("\n")
-      lines.each do |pkg|
-        list = pkg.split(/ +/)
-        updates[list[0]] = {}
-        updates[list[0]]['current'] = list[1]
-        updates[list[0]]['update'] = Facter::Util::Resolution.exec("pkg info -r #{list[0]}").scan(/Version: (.*)/)[0][0]
+      lines = Facter::Util::Resolution.exec(command)
+      if lines
+        split_lines = lines.split("\n")
+        split_lines.each do |pkg|
+          list = pkg.split(/ +/)
+          updates[list[0]] = {}
+          updates[list[0]]['current'] = list[1]
+          updates[list[0]]['update'] = Facter::Util::Resolution.exec("pkg info -r #{list[0]}").scan(/Version: (.*)/)[0][0]
+        end
       end
     end
     return updates if updates.length != 0


### PR DESCRIPTION
Without this change when pkgupdates runs on solaris and no package
updates are available catalog compilation fails because pkgupdates
cannot perform a split operation on nil. This commit moves usage of the
split function to a separate variable after validating that lines is not
nil.