### PR TITLE
Fix usage of check-update when RedHat

### DIFF
--- a/lib/facter/util/pkgupdates.rb
+++ b/lib/facter/util/pkgupdates.rb
@@ -20,7 +20,7 @@ module Facter::Util::Pkgupdates
         end
       end
     when 'RedHat'
-      command = 'yum --quiet check-upgrade'
+      command = 'yum --quiet check-update'
       lines = Facter::Util::Resolution.exec(command).split("\n").drop(1)
       lines.each do |pkg|
         list = pkg.split(/ +/)


### PR DESCRIPTION
This commit updates the command used to check for updates on RedHat OS. Specifically, the command was previously check-upgrade, which does not work. This commit resolves this issue by updating the command to check-update