### PR TITLE
Improve Solaris support for no updates

### DIFF
--- a/lib/facter/util/pkgupdates.rb
+++ b/lib/facter/util/pkgupdates.rb
@@ -29,15 +29,17 @@ module Facter::Util::Pkgupdates
         updates[list[0]]['update'] = list[1].split(':')[-1]
       end
     when 'Solaris'
-      command = 'pkg list -u -H'
-      lines = Facter::Util::Resolution.exec(command)
-      if lines
-        split_lines = lines.split("\n")
-        split_lines.each do |pkg|
-          list = pkg.split(/ +/)
-          updates[list[0]] = {}
-          updates[list[0]]['current'] = list[1]
-          updates[list[0]]['update'] = Facter::Util::Resolution.exec("pkg info -r #{list[0]}").scan(/Version: (.*)/)[0][0]
+      if system('pkg list -u -H > /dev/null 2>&1')
+        command = 'pkg list -u -H'
+        lines = Facter::Util::Resolution.exec(command)
+        if lines
+          split_lines = lines.split("\n")
+          split_lines.each do |pkg|
+            list = pkg.split(/ +/)
+            updates[list[0]] = {}
+            updates[list[0]]['current'] = list[1]
+            updates[list[0]]['update'] = Facter::Util::Resolution.exec("pkg info -r #{list[0]}").scan(/Version: (.*)/)[0][0]
+          end
         end
       end
     end


### PR DESCRIPTION
Without this change the output from the command used to check for updates on Solaris is printed in the output of the facter command run when executing a puppet run. This commit adds an if statement in front of the command in order to exit cleanly if there are no updates available